### PR TITLE
Show Certificate Files Upload buttons in ZCS 10

### DIFF
--- a/js/ZaDomainCertUpload.js
+++ b/js/ZaDomainCertUpload.js
@@ -42,20 +42,13 @@ ZaDomainCertUpload.myXFormModifier = function(xFormObject) {
     ]};
     var bottomSpace = {type:_SPACER_, height:"10"};
     var tempItems;
-    if (ZaServerVersionInfo.version.split(".")[0] == "8") {
-        var tabChoices = this.getTabChoices();
-        for (var i = 0; i < tabChoices.length; i++) {
-            if (tabChoices[i].label == ZaMsg.TABT_Certificate && xFormObject.items[2].items[i].id == "domain_form_cert_tab") {
-                tempItems = xFormObject.items[2].items[i].items;
-                tempItems.splice(3,0,uploadCertUI, bottomSpace);
-                break;
-            }
+    var tabChoices = this.getTabChoices();
+    for (var i = 0; i < tabChoices.length; i++) {
+        if (tabChoices[i].label == ZaMsg.TABT_Certificate && xFormObject.items[2].items[i].id == "domain_form_cert_tab") {
+            tempItems = xFormObject.items[2].items[i].items;
+            tempItems.splice(3,0,uploadCertUI, bottomSpace);
+            break;
         }
-    } else {  // support 7.0.0, place the UI items as the last one
-        var tablen = xFormObject.items[2].items.length;
-        tempItems = xFormObject.items[2].items[tablen>0?(tablen-1):0].items;
-        var itemlen = tempItems.length;
-        tempItems.splice(itemlen,0,uploadCertUI, bottomSpace);
     }
 }
 


### PR DESCRIPTION
When editing a domain the certificates tab is supposed to have some upload buttons at the very bottom.

This is no longer the case in ZCS 10.x.x.

I think this was introduced in:

- https://github.com/Zimbra/zm-certificate-manager-admin-zimlet/pull/5 by assuming that Zimbra would remain on ZCS 8.x.x for ever.

This commit implies that ZCS 7.x.x is not supported nowadays. If it's still supported I guess you could just change:

```
== "8"
```

and use:

```
>= "8" instead.
```

This problem should also happen in ZCS 9 and it would be fixed too.

![image](https://github.com/user-attachments/assets/d6a6d2e4-6612-420e-9a68-2cd4823fc8af)
